### PR TITLE
js copy functions wrappers

### DIFF
--- a/pkg/app/js.go
+++ b/pkg/app/js.go
@@ -193,3 +193,21 @@ type Event struct {
 func (e Event) PreventDefault() {
 	e.Call("preventDefault")
 }
+
+// CopyBytesToGo copies bytes from the Uint8Array src to dst. It returns the
+// number of bytes copied, which will be the minimum of the lengths of src and
+// dst.
+//
+// CopyBytesToGo panics if src is not an Uint8Array.
+func CopyBytesToGo(dst []byte, src Value) int {
+	return copyBytesToGo(dst, src)
+}
+
+// CopyBytesToJS copies bytes from src to the Uint8Array dst. It returns the
+// number of bytes copied, which will be the minimum of the lengths of src and
+// dst.
+//
+// CopyBytesToJS panics if dst is not an Uint8Array.
+func CopyBytesToJS(dst Value, src []byte) int {
+	return copyBytesToJS(dst, src)
+}

--- a/pkg/app/js_nowasm.go
+++ b/pkg/app/js_nowasm.go
@@ -141,3 +141,13 @@ func (w browserWindow) CursorPosition() (x, y int) {
 func (w browserWindow) setCursorPosition(x, y int) {
 	panicNoWasm()
 }
+
+func copyBytesToGo(dst []byte, src Value) int {
+	panicNoWasm()
+	return 0
+}
+
+func copyBytesToJS(dst Value, src []byte) int {
+	panicNoWasm()
+	return 0
+}

--- a/pkg/app/js_wasm.go
+++ b/pkg/app/js_wasm.go
@@ -183,3 +183,11 @@ func jsval(v Value) js.Value {
 		return js.Undefined()
 	}
 }
+
+func copyBytesToGo(dst []byte, src Value) int {
+	return js.CopyBytesToGo(dst, jsval(src))
+}
+
+func copyBytesToJS(dst Value, src []byte) int {
+	return js.CopyBytesToJS(jsval(dst), src)
+}


### PR DESCRIPTION
## Summary
This PR provides `syscall/js` wrapper for copy functions.

## Fixes
- fix #359 