### PR TITLE
add guard when updating component

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -29,6 +29,7 @@ var (
 	remoteRootDir string
 	routes        router
 	uiChan        = make(chan func(), 256)
+	dispatcher    = Dispatch
 )
 
 // EventHandler represents a function that can handle HTML events.
@@ -55,7 +56,7 @@ func Run() {
 
 // Navigate navigates to the given URL.
 func Navigate(rawurl string) {
-	Dispatch(func() {
+	dispatcher(func() {
 		u, err := url.Parse(rawurl)
 		if err != nil {
 			log.Error("navigating to page failed").
@@ -79,7 +80,7 @@ func Navigate(rawurl string) {
 
 // Reload reloads the current page.
 func Reload() {
-	Dispatch(func() {
+	dispatcher(func() {
 		reload()
 	})
 }
@@ -91,7 +92,7 @@ func Window() BrowserWindow {
 
 // NewContextMenu displays a context menu filled with the given menu items.
 func NewContextMenu(menuItems ...MenuItemNode) {
-	Dispatch(func() {
+	dispatcher(func() {
 		newContextMenu(menuItems...)
 	})
 }

--- a/pkg/app/compo.go
+++ b/pkg/app/compo.go
@@ -110,7 +110,11 @@ func (c *Compo) replaceChild(old, new UI) {
 // Update update the component appearance. It should be called when a field
 // used to render the component has been modified.
 func (c *Compo) Update() {
-	Dispatch(func() {
+	dispatcher(func() {
+		if c.compo == nil {
+			return
+		}
+
 		current := c.root
 		incoming := c.compo.Render().(UI)
 

--- a/pkg/app/compo_test.go
+++ b/pkg/app/compo_test.go
@@ -1,0 +1,44 @@
+package app
+
+import "testing"
+
+type boo struct {
+	Compo
+}
+
+func (b *boo) Render() UI {
+	return Text("foo")
+}
+
+type booWithDefaultRender struct {
+	Compo
+}
+
+func TestCompoUmountedUpdate(t *testing.T) {
+	tests := []struct {
+		scenario string
+		compo    Composer
+	}{
+		{
+			scenario: "component with redefined render is updated",
+			compo:    &boo{},
+		},
+		{
+			scenario: "component without redefined render is updated",
+			compo:    &booWithDefaultRender{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			dispatcher = func(f func()) {
+				f()
+			}
+			defer func() {
+				dispatcher = Dispatch
+			}()
+
+			test.compo.Update()
+		})
+	}
+}

--- a/pkg/app/elem.go
+++ b/pkg/app/elem.go
@@ -154,7 +154,7 @@ func (e *elem) setEventHandler(k string, h EventHandler) {
 
 func (e *elem) setEventHandlerValue(k string, h eventHandler) {
 	callback := FuncOf(func(this Value, args []Value) interface{} {
-		Dispatch(func() {
+		dispatcher(func() {
 			event := Event{Value: args[0]}
 			trackMousePosition(event)
 			h.function(this, event)


### PR DESCRIPTION
## Summary
This PR makes a component update to be skipped when the component is not mounted.

## Fixes
- fix #364 