### PR TITLE
Modify the body element before mounting

### DIFF
--- a/pkg/app/http.go
+++ b/pkg/app/http.go
@@ -80,6 +80,9 @@ type Handler struct {
 	// The name of the web application as it is usually displayed to the user.
 	Name string
 
+	// Customize the body element before mounting
+	OnBody func(body HTMLBody)
+
 	// The cache that stores pre-rendered pages.
 	//
 	// Default is a LRU cache that keeps pages up to 24h and have a maximum size
@@ -610,6 +613,9 @@ func (h *Handler) servePage(w http.ResponseWriter, r *http.Request) {
 		),
 		Div().ID("app-end"),
 	)
+	if h.OnBody != nil {
+		h.OnBody(body)
+	}
 	if err := mount(&disp, body); err != nil {
 		panic(errors.New("mounting pre-rendering container failed").
 			Tag("server-side", disp.runsInServer()).


### PR DESCRIPTION
Hello! I was trying add a single data attribute to the body element before mounting the page (without implementing a handler from scratch). Is there is a better way to do this?
I tried checking the `Page` interface win the pretender phase but it doesn't expose the body element.
```go
http.Handle("/", &app.Handler{
		Author:      "gabs",
		Description: "Example Webapp",
		Name:        "Example",
		Styles:      []string{"/web/halfmoon-variables.css", "/web/style.css"},
		Scripts:     []string{"/web/halfmoon.js"},
		OnBody: func(body app.HTMLBody){
			body.DataSet("set-preferred-mode-onload", "true") // this is what I need: <body data-set-preferred-mode-onload="true">
		},
	})
```

This is how I got it to work. If there's a proper way to do this, feel free to close.