### PR TITLE
Add ability to route to a function that builds a component

### DIFF
--- a/pkg/app/route_test.go
+++ b/pkg/app/route_test.go
@@ -15,6 +15,22 @@ type routeWithRegexpCompo struct {
 	Compo
 }
 
+type routeFactoryCompo struct {
+	Compo
+}
+
+type routeWithRegexpFactoryCompo struct {
+	Compo
+}
+
+func routefactory() Composer {
+	return &routeFactoryCompo{}
+}
+
+func routeWithRegexpFactory() Composer {
+	return &routeWithRegexpFactoryCompo{}
+}
+
 func TestRoutes(t *testing.T) {
 	utests := []struct {
 		scenario     string
@@ -58,6 +74,23 @@ func TestRoutes(t *testing.T) {
 				r.routeWithRegexp("^/a.*$", &routeWithRegexpCompo{})
 			},
 			expected: &routeWithRegexpCompo{},
+		},
+		{
+			scenario: "path with factory is routed",
+			createRoutes: func(r *router) {
+				r.routeFactory("/a", routefactory)
+			},
+			expected: &routeFactoryCompo{},
+			path:     "/a",
+		},
+		{
+			scenario: "pattern with factory is routed",
+			path:     "/ab",
+			createRoutes: func(r *router) {
+				r.routeFactory("/abc", routefactory)
+				r.routeWithRegexpFactory("^/a.*$", routeWithRegexpFactory)
+			},
+			expected: &routeWithRegexpFactoryCompo{},
 		},
 		{
 			scenario: "pattern with inner wildcard is routed",


### PR DESCRIPTION
Adds new public methods `RouteFactory` and `RouteWithRegexpFactory` that allow a developer to specify a function to build a new component when a route is matched. This is intended to allow the creation of powerful generic components, example below.

```golang
type Page struct {
	app.Compo
	pageContent app.Composer
}

func (p *Page) Render() app.UI {
	return app.Div().Body(
		newNavBar(), // imagine a `type NavBar struct { app.Compo ...}` somewhere
		p.pageContent,
	)
}

func pageFor(cf app.ComposerFactory) app.ComposerFactory {
	return func() app.Composer {
		return &Page{
			pageContent: cf(),
		}
	}
}

type User struct {
	app.Compo
	name  string
	posts []BlogPost
}

func (u *User) Render() app.UI {
	return app.Div().Body(
		app.H1().Body(
			app.Text(u.name),
		),
		app.Range(u.posts).Slice(func(i int) app.UI {
			return app.A().Href(fmt.Sprintf("/post/%s", u.posts[i].title)).Body(
				app.Text(u.posts[i].title),
			)
		}),
	)
}

func newUser() app.Composer {
	return &User{}
}

type BlogPost struct {
	app.Compo
	title string
	body  string
}

func (bp *BlogPost) Render() app.UI {
	return app.Div().Body(
		app.H1().Body(
			app.Text(bp.title),
		),
		app.P().Body(
			app.Text(bp.body),
		),
	)
}

func newBlogPost() app.Composer {
	return &BlogPost{}
}

func main() {
	app.RouteWithRegexpFactory("^/user/[0-9]+$", pageFor(newUser))
	app.RouteWithRegexpFactory("^/post/\\w+$", pageFor(newBlogPost))
	app.RunWhenOnBrowser()

	http.Handle("/", &app.Handler{
		Name:        "Blog",
		Description: "An example blogging site",
	})

	if err := http.ListenAndServe(":8000", nil); err != nil {
		log.Fatal(err)
	}
}

```