### PR TITLE
GOPATH is not (anymore) mandatory to be set with modern Go

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 bootstrap:
 	@echo "\033[94m• Setting up go test for wasm to run in the browser\033[00m"
 	GO111MODULE=off go get -u github.com/agnivade/wasmbrowsertest
-	mv ${GOPATH}/bin/wasmbrowsertest ${GOPATH}/bin/go_js_wasm_exec
+	mv `go env GOPATH`/bin/wasmbrowsertest `go env GOPATH`/bin/go_js_wasm_exec
 	GO111MODULE=off go get -u golang.org/x/tools/cmd/godoc
 
 .PHONY: test

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 bootstrap:
 	@echo "\033[94m• Setting up go test for wasm to run in the browser\033[00m"
-	GO111MODULE=off go get -u github.com/agnivade/wasmbrowsertest
+	go install github.com/agnivade/wasmbrowsertest@latest
 	mv `go env GOPATH`/bin/wasmbrowsertest `go env GOPATH`/bin/go_js_wasm_exec
-	GO111MODULE=off go get -u golang.org/x/tools/cmd/godoc
+	go install golang.org/x/tools/cmd/godoc@lastest
 
 .PHONY: test
 test:


### PR DESCRIPTION
I could not run make out of the box.

Using `go env GOPATH` should be compatible with old and new setups.

Notice: To change GOPATH one should use `go env -w GOPATH=/other/bin`