### PR TITLE
Added OnBeforeMount

### DIFF
--- a/pkg/app/component.go
+++ b/pkg/app/component.go
@@ -64,6 +64,16 @@ type PreRenderer interface {
 	OnPreRender(Context)
 }
 
+// BeforeMounter is the interface that describes a component that can perform
+// additional actions before it mounted.
+type BeforeMounter interface {
+	Composer
+
+	// The function called before the component is mounted. It is always called on
+	// the UI goroutine.
+	OnBeforeMount(Context)
+}
+
 // Mounter is the interface that describes a component that can perform
 // additional actions when mounted.
 type Mounter interface {
@@ -272,6 +282,11 @@ func (c *Compo) mount(d Dispatcher) error {
 			Tag("reason", "already mounted").
 			Tag("name", c.name()).
 			Tag("kind", c.Kind())
+	}
+
+	if beforeMounter, ok := c.self().(BeforeMounter); ok {
+		c.dispatch(beforeMounter.OnBeforeMount)
+		return nil
 	}
 
 	c.disp = d


### PR DESCRIPTION
This event is needed when component need to init its own state before first render.

This hook is similar to vue hook :
https://v3.vuejs.org/api/options-lifecycle-hooks.html#beforemount

Sometimes we need to initialize state of component before first render