### PR TITLE
Adds an OnInit() function

### DIFF
--- a/pkg/app/component.go
+++ b/pkg/app/component.go
@@ -64,6 +64,15 @@ type PreRenderer interface {
 	OnPreRender(Context)
 }
 
+// Initialiser is the interface that describes a component that can perform
+// additional initialisations once before it is the first time rendered.
+type Initialiser interface {
+	Composer
+
+	// The function called once before the component is rendered the first time.
+	OnInit()
+}
+
 // Mounter is the interface that describes a component that can perform
 // additional actions when mounted.
 type Mounter interface {
@@ -272,6 +281,11 @@ func (c *Compo) mount(d Dispatcher) error {
 			Tag("reason", "already mounted").
 			Tag("name", c.name()).
 			Tag("kind", c.Kind())
+	}
+
+	if Initialiser, ok := c.self().(Initialiser); ok && c.disp == nil {
+		// will only run once even with multiple dismount/mounts
+		Initialiser.OnInit()
 	}
 
 	c.disp = d

--- a/pkg/app/component_test.go
+++ b/pkg/app/component_test.go
@@ -429,6 +429,27 @@ func TestUpdater(t *testing.T) {
 	require.True(t, b.updated)
 }
 
+func TestInitializerServer(t *testing.T) {
+	h := &bar{}
+	d := NewServerTester(h)
+	defer d.Close()
+
+	d.PreRender()
+	d.Consume()
+	require.Equal(t, "bar", d.currentPage().Title())
+}
+
+func TestInitializerClient(t *testing.T) {
+	h := &bar{}
+	d := NewClientTester(h)
+	d.Mount(h)
+	d.Mount(h)
+	d.Consume()
+	defer d.Close()
+
+	require.Equal(t, "bar", h.title)
+}
+
 type hello struct {
 	Compo
 
@@ -498,10 +519,15 @@ type bar struct {
 	appInstalled bool
 	appRezized   bool
 	updated      bool
+	title        string
+}
+
+func (b *bar) OnInit() {
+	b.title+="bar"
 }
 
 func (b *bar) OnPreRender(ctx Context) {
-	ctx.Page().SetTitle("bar")
+	ctx.Page().SetTitle(b.title)
 }
 
 func (b *bar) OnNav(ctx Context) {


### PR DESCRIPTION
It is called once and before the first OnRender() such that it can be used to initialize Data structures without the need to check for their initialization in the render routine.