### PR TITLE
Fix custom provider with empty prefix

### DIFF
--- a/pkg/app/resource.go
+++ b/pkg/app/resource.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"net/http"
+	"path/filepath"
 	"strings"
 )
 
@@ -101,7 +102,7 @@ func CustomProvider(path, prefix string) ResourceProvider {
 	return localDir{
 		Handler: http.FileServer(http.Dir(root)),
 		root:    prefix,
-		appWASM: prefix + "/web/app.wasm",
+		appWASM: filepath.Join(prefix, "web/app.wasm"),
 	}
 }
 


### PR DESCRIPTION
Before when a CustomProvider("", "") was used,
the resulting app.js would try to fetch //web/app.wasm instead of
/web/app.wasm, which is the same as https://web/app.wasm only ignoring
the protocol.
