### PR TITLE
Added the possibility to skip updates from a event handler.

### DIFF
--- a/pkg/app/dispatcher.go
+++ b/pkg/app/dispatcher.go
@@ -20,7 +20,7 @@ type Dispatcher interface {
 
 	// Emit executes the given function and notifies the source's parent
 	// components to update their state.
-	Emit(src UI, fn func())
+	Emit(src UI, fn func() bool)
 
 	// Handle registers the handler for the given action name. When an action
 	// occurs, the handler is executed on the UI goroutine.

--- a/pkg/app/event.go
+++ b/pkg/app/event.go
@@ -36,12 +36,16 @@ func makeJsEventHandler(src UI, h EventHandler) Func {
 			Mode:   Update,
 			Source: src,
 			Function: func(ctx Context) {
-				ctx.Emit(func() {
+				ctx.Emit(func() bool {
 					event := Event{
 						Value: args[0],
 					}
 					trackMousePosition(event)
 					h(ctx, event)
+					if uictx, ok := ctx.(uiContext); ok {
+						return *uictx.skipUpdates != 0
+					}
+					return false
 				})
 			},
 		})


### PR DESCRIPTION
This is my attempt at solving #709. It keeps the current `app.EventHandler` but I had to change `Emit()`. 

I also added a test case and validated that it works in some of our code which also showed immediate benefits. I saw much lower CPU consumption on cursor movement in form fields with `OnKeyUp()` event handlers which filter cursor movement.

The way I modified the context to carry the skip updates flag feels a bit rough to me. I am probably not experienced enough and there may be a better solution?