### PR TITLE
Added the possibility to skip updates from a event handler.

### DIFF
--- a/pkg/app/dispatcher.go
+++ b/pkg/app/dispatcher.go
@@ -20,7 +20,7 @@ type Dispatcher interface {
 
 	// Emit executes the given function and notifies the source's parent
 	// components to update their state.
-	Emit(src UI, fn func())
+	Emit(src UI, fn func() bool)
 
 	// Handle registers the handler for the given action name. When an action
 	// occurs, the handler is executed on the UI goroutine.

--- a/pkg/app/event.go
+++ b/pkg/app/event.go
@@ -36,12 +36,16 @@ func makeJsEventHandler(src UI, h EventHandler) Func {
 			Mode:   Update,
 			Source: src,
 			Function: func(ctx Context) {
-				ctx.Emit(func() {
+				ctx.Emit(func() bool {
 					event := Event{
 						Value: args[0],
 					}
 					trackMousePosition(event)
 					h(ctx, event)
+					if uictx, ok := ctx.(uiContext); ok {
+						return *uictx.skipUpdates != 0
+					}
+					return false
 				})
 			},
 		})


### PR DESCRIPTION
This is an alternate version to #710 which allows to selectively skip all updates or just the parent ones. I am actually not sure if this is a thing :). It seems to do what I expect it to do by not rendering parent components, when I only want to change the current one. I may miss something though because this looks like so low-hanging fruit to save resources.