### PR TITLE
Allow setting of NotFound

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -351,7 +351,7 @@ func performNavigate(d Dispatcher, u *url.URL, updateHistory bool) {
 	}
 	compo, ok := routes.createComponent(path)
 	if !ok {
-		compo = &notFound{}
+		compo = NotFound
 	}
 
 	disp, ok := d.(ClientDispatcher)

--- a/pkg/app/notfound.go
+++ b/pkg/app/notfound.go
@@ -3,7 +3,7 @@ package app
 var (
 	// NotFound is the ui element that is displayed when a request is not
 	// routed.
-	NotFound UI = &notFound{}
+	NotFound Composer = &notFound{}
 )
 
 type notFound struct {


### PR DESCRIPTION
Currently, setting `app.NotFound` has no effect when a route is not found. This PR allows for custom NotFound components.