### PR TITLE
Fixing attribute names "accept-charset" and "http-equiv"

### DIFF
--- a/pkg/app/gen/html.go
+++ b/pkg/app/gen/html.go
@@ -2230,6 +2230,13 @@ func writeAttrFunction(w io.Writer, a attr, t tag, isInterface bool) {
 		fmt.Fprintf(w, "func (e *html%s)", t.Name)
 	}
 
+	var attrName string
+	if a.NameOverride != "" {
+		attrName = strings.ToLower(a.NameOverride)
+	} else {
+		attrName = strings.ToLower(a.Name)
+	}
+
 	switch a.Type {
 	case "data|value":
 		fmt.Fprintf(w, `%s(k string, v interface{}) HTML%s`, a.Name, t.Name)
@@ -2289,7 +2296,7 @@ func writeAttrFunction(w io.Writer, a attr, t tag, isInterface bool) {
 	
 				e.setAttr("%s", s)
 				return e
-			}`, strings.ToLower(a.Name))
+			}`, attrName)
 		}
 
 	case "bool|force":
@@ -2303,7 +2310,7 @@ func writeAttrFunction(w io.Writer, a attr, t tag, isInterface bool) {
 	
 				e.setAttr("%s", s)
 				return e
-			}`, strings.ToLower(a.Name))
+			}`, attrName)
 		}
 
 	case "url":
@@ -2312,7 +2319,7 @@ func writeAttrFunction(w io.Writer, a attr, t tag, isInterface bool) {
 			fmt.Fprintf(w, `{
 				e.setAttr("%s", v)
 				return e
-			}`, strings.ToLower(a.Name))
+			}`, attrName)
 		}
 
 	case "string|class":
@@ -2321,7 +2328,7 @@ func writeAttrFunction(w io.Writer, a attr, t tag, isInterface bool) {
 			fmt.Fprintf(w, `{
 				e.setAttr("%s", strings.Join(v, " "))
 				return e
-			}`, strings.ToLower(a.Name))
+			}`, attrName)
 		}
 
 	default:
@@ -2330,7 +2337,7 @@ func writeAttrFunction(w io.Writer, a attr, t tag, isInterface bool) {
 			fmt.Fprintf(w, `{
 				e.setAttr("%s", v)
 				return e
-			}`, strings.ToLower(a.Name))
+			}`, attrName)
 		}
 	}
 }

--- a/pkg/app/html.go
+++ b/pkg/app/html.go
@@ -16907,7 +16907,7 @@ func (e *htmlForm) Text(v interface{}) HTMLForm {
 }
 
 func (e *htmlForm) AcceptCharset(v string) HTMLForm {
-	e.setAttr("acceptcharset", v)
+	e.setAttr("accept-charset", v)
 	return e
 }
 
@@ -27493,7 +27493,7 @@ func (e *htmlMeta) Draggable(v bool) HTMLMeta {
 }
 
 func (e *htmlMeta) HTTPEquiv(v string) HTMLMeta {
-	e.setAttr("httpequiv", v)
+	e.setAttr("http-equiv", v)
 	return e
 }
 


### PR DESCRIPTION
It seems like attr.NameOverride got lost in the implementation. The former code generated:

`<meta httpequiv="Content-Type" content="text/html; charset=utf-8">` instead off
`<meta http-equiv="Content-Type" content="text/html; charset=utf-8">`