### PR TITLE
This changes the event handler scope to the actuall ptr if one is used.

### DIFF
--- a/pkg/app/strings.go
+++ b/pkg/app/strings.go
@@ -32,7 +32,11 @@ func toString(v any) string {
 		return ""
 
 	default:
-		return fmt.Sprint(v)
+		val := reflect.ValueOf(v)
+		if val.Kind() != reflect.Ptr {
+			return fmt.Sprint(v)
+		}
+		return val.String()
 	}
 }
 


### PR DESCRIPTION
I have a project where I need a scope based on the pointer to a
structure (which is an alternative app.UI). There I need to add the
scope to the event handler. I used a pointer but after some
investigations I made lately I found that this gets converted to a
string using `fmt.Sprint()` which actually "dumps" the contents of the
struct into a string. I believe that is not what it should be. It will
also use the content of a pointer to a struct containing a string and
they can easily be equal to other strings.

Making the proposed changed will use a string representation of the
pointer itself for the scope. This works very well for me. I currently
use a scope with a string generated by `fmt.Sprintf("%p",ptr)` in my
code, but I think this change should go into go-app directly.

I made this PR onto v9.6.0 but it could be applied to master without changes too.