### PR TITLE
Fixing invalid double set charset meta headers

### DIFF
--- a/pkg/app/http.go
+++ b/pkg/app/http.go
@@ -679,9 +679,6 @@ func (h *Handler) servePage(w http.ResponseWriter, r *http.Request) {
 			Head().Body(
 				Meta().Charset("UTF-8"),
 				Meta().
-					HTTPEquiv("Content-Type").
-					Content("text/html; charset=utf-8"),
-				Meta().
 					Name("author").
 					Content(page.Author()),
 				Meta().


### PR DESCRIPTION
Having meta charset and the "http-equiv" together is [invalid](https://rocketvalidator.com/html-validation/a-document-must-not-include-both-a-meta-element-with-an-http-equiv-attribute-whose-value-is-content-type-and-a-meta-element-with-a-charset-attribute). I just had some rounds of HTML validator going for pages, and this was the "not solvable" problem. There are others like invalid meta tags if you leave out keywords or such. But that can be worked around (still should be fixed IMHO).

Also, as PR on v9.6.0 only.