### PR TITLE
When the go-app site is served over TLS the proxied resources are loaded through http

### DIFF
--- a/pkg/app/http.go
+++ b/pkg/app/http.go
@@ -6,7 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -593,7 +593,13 @@ func (h *Handler) servePreRenderedItem(w http.ResponseWriter, r PreRenderedItem)
 func (h *Handler) serveProxyResource(resource ProxyResource, w http.ResponseWriter, r *http.Request) {
 	var u string
 	if _, ok := h.Resources.(http.Handler); ok {
-		u = "http://" + r.Host + resource.ResourcePath
+		var protocol string
+		if r.TLS != nil {
+			protocol = "https://"
+		} else {
+			protocol = "http://"
+		}
+		u = protocol + r.Host + resource.ResourcePath
 	} else {
 		u = h.Resources.Static() + resource.ResourcePath
 	}
@@ -616,7 +622,7 @@ func (h *Handler) serveProxyResource(resource ProxyResource, w http.ResponseWrit
 		return
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		Log(errors.New("reading proxy static resource failed").


### PR DESCRIPTION
When the go-app site is served over TLS, the proxied resources are loaded through HTTP instead of HTTPS. There may be no HTTP endpoint, and there may also not be the same files, so I think it should use HTTPS if TLS is used.

I found this while wondering why my HTTP redirector redirects a web/robots.txt to HTTPS. This should not be the case when querying the HTTPS page.

P.S.: I also changed the ReadAll() from the deprecated ioutils version to the one in that io package.