### PR TITLE
fix: remove infinite loop in replaceRoot

### DIFF
--- a/pkg/app/component.go
+++ b/pkg/app/component.go
@@ -408,12 +408,12 @@ func (c *Compo) replaceRoot(v UI) error {
 			Wrap(err)
 	}
 
-	var parent UI
+	parent := c.getParent()
 	for {
-		parent = c.getParent()
 		if parent == nil || parent.Kind() == HTML {
 			break
 		}
+		parent = parent.getParent()
 	}
 
 	if parent == nil {


### PR DESCRIPTION
Hi @maxence-charriere 

I ran into infinite loop when tried implementing something like this:
```go
package main

import (
	"log"
	"net/http"

	"github.com/maxence-charriere/go-app/v9/pkg/app"
)

type compo struct {
	app.Compo
}

func (c *compo) Render() app.UI {
	return app.Div().Body(new(compoA))
}

type compoA struct {
	app.Compo
	isLoading bool
}

func (c *compoA) OnNav(app.Context) {
	c.isLoading = true
}

func (c *compoA) Render() app.UI {
	b := new(compoB)
	b.IsLoading = c.isLoading
	return b
}

type compoB struct {
	app.Compo
	IsLoading bool
}

func (c *compoB) Render() app.UI {
	return app.If(c.IsLoading, app.Div().Text("is loading")).Else(app.A().Text("is not loading"))
}

func main() {
	app.Route("/", new(compo))

	app.RunWhenOnBrowser()

	http.Handle("/", &app.Handler{
		Name:        "Hello",
		Description: "An Hello World! example",
	})

	if err := http.ListenAndServe(":8000", nil); err != nil {
		log.Fatal(err)
	}
}
```