### PR TITLE
fix cleanArg and rework JSValue(app.Value)

### DIFF
--- a/pkg/app/js_nowasm.go
+++ b/pkg/app/js_nowasm.go
@@ -215,6 +215,13 @@ func (w *browserWindow) addHistory(u *url.URL) {
 func (w *browserWindow) replaceHistory(u *url.URL) {
 }
 
+// JSValue returns the underlying syscall/js value of the given Javascript
+// value.
+// Returns the parameter v for non-wasm builds.
+func JSValue(v Value) any {
+	return v
+}
+
 func copyBytesToGo(dst []byte, src Value) int {
 	return 0
 }

--- a/pkg/app/js_wasm.go
+++ b/pkg/app/js_wasm.go
@@ -49,6 +49,7 @@ func (v value) InstanceOf(t Value) bool {
 }
 
 func (v value) Invoke(args ...any) Value {
+	args = cleanArgs(args...)
 	return val(v.Value.Invoke(args...))
 }
 
@@ -334,7 +335,7 @@ func jsval(v Value) js.Value {
 
 // JSValue returns the underlying syscall/js value of the given Javascript
 // value.
-func JSValue(v Value) js.Value {
+func JSValue(v Value) any {
 	return jsval(v)
 }
 
@@ -367,8 +368,12 @@ func cleanArg(v any) any {
 	case []any:
 		s := make([]any, len(v))
 		for i, val := range v {
-			s[i] = cleanArgs(val)
+			s[i] = cleanArg(val)
 		}
+		return s
+
+	case function:
+		return v.fn
 
 	case Wrapper:
 		return jsval(v.JSValue())

--- a/pkg/app/js_wasm_test.go
+++ b/pkg/app/js_wasm_test.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"syscall/js"
+	"testing"
+)
+
+var sampleFuncOf = func(this Value, args []Value) any { return nil }
+
+func TestCleanArg(t *testing.T) {
+
+	t.Run(fmt.Sprintf("cleanArg slice"), func(t *testing.T) {
+		arg := cleanArg([]any{"string", FuncOf(sampleFuncOf)})
+		switch ta := arg.(type) {
+		case []any:
+			require.Equal(t, 2, len(ta))
+			require.Equal(t, "string", ta[0])
+			require.IsType(t, js.Func{}, ta[1])
+			return
+		}
+		t.Fail()
+	})
+
+	t.Run(fmt.Sprintf("cleanArg func"), func(t *testing.T) {
+		require.IsType(t, js.Func{}, cleanArg(FuncOf(sampleFuncOf)))
+	})
+
+	t.Run(fmt.Sprintf("cleanArg string"), func(t *testing.T) {
+		require.Equal(t, "string", cleanArg("string"))
+	})
+
+}
+
+func TestJSValue(t *testing.T) {
+
+	t.Run("test JSValue(app.Value) any", func(t *testing.T) {
+		global := js.Global()
+		require.True(t, global.Equal(js.ValueOf(JSValue(ValueOf(global)))))
+	})
+
+}


### PR DESCRIPTION
This PR addresses https://github.com/maxence-charriere/go-app/issues/876

* Adds `func JSValue(v Value) any` to `js_nowasm.go` and changes return type on matching function in `js_wasm.go`
* Fixes  cleanArg() where slices and functions were getting passed down incorrectly to syscall/js
* Some basic unit tests in `js_wasm.go` to validate fixes