### PR TITLE
Refactor storage api

### DIFF
--- a/pkg/app/state.go
+++ b/pkg/app/state.go
@@ -407,22 +407,14 @@ func (m *stateManager) Cleanup() {
 // remove any persisted states that have expired. This method ensures that the
 // local storage is kept clean by eliminating outdated or irrelevant state data.
 func (m *stateManager) CleanupExpiredPersistedStates(ctx Context) {
-	object := Window().Get("Object")
-	if !object.Truthy() {
-		return
-	}
-
-	keys := object.Call("keys", Window().Get("localStorage"))
-	for i, l := 0, keys.Get("length").Int(); i < l; i++ {
-		key := keys.Index(i).String()
-
+	ctx.LocalStorage().ForEach(func(key string) {
 		var state storableState
 		ctx.LocalStorage().Get(key, &state)
-
-		if (len(state.Value) != 0 || len(state.EncryptedValue) != 0) && expiredTime(state.ExpiresAt) {
+		if (len(state.Value) != 0 || len(state.EncryptedValue) != 0) &&
+			expiredTime(state.ExpiresAt) {
 			ctx.LocalStorage().Del(key)
 		}
-	}
+	})
 }
 
 func storeValue(recv, v any) error {

--- a/pkg/app/storage.go
+++ b/pkg/app/storage.go
@@ -23,9 +23,6 @@ type BrowserStorage interface {
 	// Len returns the number of items stored.
 	Len() int
 
-	// Key returns the key of the item associated to the given index.
-	Key(i int) (string, error)
-
 	// Clear deletes all items.
 	Clear()
 }

--- a/pkg/app/storage_test.go
+++ b/pkg/app/storage_test.go
@@ -59,6 +59,10 @@ func testBrowserStorage(t *testing.T, s BrowserStorage) {
 			scenario: "len returns the storage length",
 			function: testBrowserStorageLen,
 		},
+		{
+			scenario: "foreach iterates over each storage keys",
+			function: testBrowserStorageForEach,
+		},
 	}
 
 	for _, test := range tests {
@@ -163,4 +167,31 @@ func testBrowserStorageLen(t *testing.T, s BrowserStorage) {
 	s.Set("bye", 42)
 
 	require.Equal(t, 3, s.Len())
+}
+
+func testBrowserStorageForEach(t *testing.T, s BrowserStorage) {
+	s.Clear()
+
+	keys := []string{
+		"starwars",
+		"startrek",
+		"alien",
+		"marvel",
+		"dune",
+		"lords of the rings",
+	}
+	for _, k := range keys {
+		s.Set(k, 3000)
+	}
+	require.Equal(t, s.Len(), len(keys))
+
+	keyMap := make(map[string]struct{})
+	s.ForEach(func(key string) {
+		keyMap[key] = struct{}{}
+	})
+	require.Len(t, keyMap, len(keys))
+
+	for _, k := range keys {
+		require.Contains(t, keyMap, k)
+	}
 }

--- a/pkg/app/storage_test.go
+++ b/pkg/app/storage_test.go
@@ -56,14 +56,6 @@ func testBrowserStorage(t *testing.T, s BrowserStorage) {
 			function: testBrowserStorageGetError,
 		},
 		{
-			scenario: "get key at given index",
-			function: testBrowserStorageKey,
-		},
-		{
-			scenario: "get key at given index returns an error",
-			function: testBrowserStorageKeyError,
-		},
-		{
 			scenario: "len returns the storage length",
 			function: testBrowserStorageLen,
 		},
@@ -161,22 +153,6 @@ func testBrowserStorageFull(t *testing.T, s BrowserStorage) {
 
 	require.Error(t, err)
 	t.Log(err)
-}
-
-func testBrowserStorageKey(t *testing.T, s BrowserStorage) {
-	s.Clear()
-
-	err := s.Set("hello", 42)
-	require.NoError(t, err)
-
-	v, err := s.Key(0)
-	require.NoError(t, err)
-	require.Equal(t, "hello", v)
-}
-
-func testBrowserStorageKeyError(t *testing.T, s BrowserStorage) {
-	_, err := s.Key(42)
-	require.Error(t, err)
 }
 
 func testBrowserStorageLen(t *testing.T, s BrowserStorage) {

--- a/pkg/app/storage_test.go
+++ b/pkg/app/storage_test.go
@@ -63,6 +63,11 @@ func testBrowserStorage(t *testing.T, s BrowserStorage) {
 			scenario: "foreach iterates over each storage keys",
 			function: testBrowserStorageForEach,
 		},
+
+		{
+			scenario: "contains reports an existing key",
+			function: testBrowserStorageContains,
+		},
 	}
 
 	for _, test := range tests {
@@ -194,4 +199,12 @@ func testBrowserStorageForEach(t *testing.T, s BrowserStorage) {
 	for _, k := range keys {
 		require.Contains(t, keyMap, k)
 	}
+}
+
+func testBrowserStorageContains(t *testing.T, s BrowserStorage) {
+	s.Clear()
+
+	require.False(t, s.Contains("lightsaber"))
+	s.Set("lightsaber", true)
+	require.True(t, s.Contains("lightsaber"))
 }


### PR DESCRIPTION
 Modified `BrowserStorage` following @oderwat feedback.
- Removed `BrowserStoragej.Key()` method 
- Added `BrowserStoragej.ForEach()` method
- Added `BrowserStoragej.Contains()` method