### PR TITLE
state broadcast refactor

### DIFF
--- a/pkg/app/engine.go
+++ b/pkg/app/engine.go
@@ -162,7 +162,6 @@ func (e *engineX) initBrowser() {
 		return
 	}
 	e.browser.HandleEvents(e.baseContext(), e.notifyComponentEvent)
-	e.states.InitBroadcast(e.baseContext())
 }
 
 func (e *engineX) notifyComponentEvent(event any) {


### PR DESCRIPTION
state broadcast now requires for an observer to specify that it also observer broadcasts.

Usage:
```go
var v int
ctx.ObserveState("stateName", &v).
    WithBroadcast()
```


This is to not create a BroadcastChannel by default when there is no state broadcast required. This will prevent

<img width="761" alt="Screenshot 2024-03-21 at 4 15 16 PM" src="https://github.com/maxence-charriere/go-app/assets/2692731/12e03b80-7bd0-4c1c-bf15-fc170d4094d9">
