### PR TITLE
Dead code elimination in Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ func main() {
 	app.Route("/hello", func() app.Composer { return &hello{} })
 	app.RunWhenOnBrowser()
 
-	// HTTP routing:
-	http.Handle("/", &app.Handler{
-		Name:        "Hello",
-		Description: "An Hello World! example",
-	})
-
-	if err := http.ListenAndServe(":8000", nil); err != nil {
-		log.Fatal(err)
+	if app.IsServer {
+		// HTTP routing:
+		http.Handle("/", &app.Handler{
+			Name:        "Hello",
+			Description: "An Hello World! example",
+		})
+	
+		if err := http.ListenAndServe(":8000", nil); err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 ```


### PR DESCRIPTION
Because Go compiler has dead code elimination, if we encapsulate the backend code in this `if`, as it is based on a constant value, the compiler will remove all code related to what's inside that `if` when compiling for wasm, leading to considerable size reduction.

(In my playground app it reduces size from 21MB to 17MB uncompressed)