### PR TITLE
fix asset paths/URLs becoming lowercased

### DIFF
--- a/pkg/app/http.go
+++ b/pkg/app/http.go
@@ -860,19 +860,19 @@ func parseHTTPResource(v string) httpResource {
 		if elem = strings.TrimSpace(elem); elem == "" {
 			continue
 		}
-		elem = strings.ToLower(elem)
+		lower := strings.ToLower(elem)
 
 		switch {
-		case elem == "crossorigin":
+		case lower == "crossorigin":
 			res.CrossOrigin = "true"
 
-		case strings.HasPrefix(elem, "crossorigin="):
-			res.CrossOrigin = strings.TrimPrefix(elem, "crossorigin=")
+		case strings.HasPrefix(lower, "crossorigin="):
+			res.CrossOrigin = strings.TrimPrefix(lower, "crossorigin=")
 
-		case elem == "defer":
+		case lower == "defer":
 			res.LoadingMode = "defer"
 
-		case elem == "async":
+		case lower == "async":
 			res.LoadingMode = "async"
 
 		default:

--- a/pkg/app/http_test.go
+++ b/pkg/app/http_test.go
@@ -72,6 +72,49 @@ func TestHandlerServePageWithLocalDir(t *testing.T) {
 	t.Log(body)
 }
 
+func TestHandlerPreservesURLCasing(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	h := Handler{
+		Resources: LocalDir(""),
+		Title:     "Handler testing",
+		Scripts: []string{
+			"web/Hello.js",
+			"http://boo.com/Bar.js",
+		},
+		Styles: []string{
+			"web/Foo.css",
+			"/web/Bar.css",
+			"https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded",
+		},
+		RawHeaders: []string{
+			`<meta http-equiv="refresh" content="30">`,
+		},
+		Image: "/web/test.png",
+	}
+	h.Icon.Maskable = "ios.png"
+
+	h.ServeHTTP(w, r)
+
+	body := w.Body.String()
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, body, `<html lang="en">`)
+	require.Contains(t, body, `href="/web/Foo.css"`)
+	require.Contains(t, body, `href="/web/Bar.css"`)
+	require.Contains(t, body, `href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded"`)
+	require.Contains(t, body, `src="/web/Hello.js"`)
+	require.Contains(t, body, `src="http://boo.com/Bar.js"`)
+	require.Contains(t, body, `href="/manifest.webmanifest"`)
+	require.Contains(t, body, `href="/app.css"`)
+	require.Contains(t, body, `<meta http-equiv="refresh" content="30">`)
+	require.Contains(t, body, `<div id="pre-render-ok">`)
+	require.Contains(t, body, `content="https:///web/test.png"`)
+	require.Contains(t, body, `<img src="/web/resolve-static-resource-test.jpg">`)
+
+	t.Log(body)
+}
+
 func TestHandlerServePageWithRemoteBucket(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Hiya - thanks for building Go App! I'm trialing it for a rewrite of [Dagger Cloud](https://dagger.io/blog/introducing-dagger-traces) which is a pretty dense developer-focused UI currently implemented in TypeScript/React.

I noticed last night that Google Fonts seems to have made their router case sensitive (edit: nevermind it likely always has been, it's because my server was actually still on v9, and this was a v10 change), which broke my app as fonts started returning 400 errors. Turns out Go App is lowercasing all paths/URLs that you pass to the app handler.

I'm guessing this was unintentional and mostly to make the string comparisons in the `switch` more robust, and not to actually modify the URL, so here's a PR to preserve the casing for the URL in the case where it's not one of the keywords.