### PR TITLE
dismount enforcer

### DIFF
--- a/pkg/app/component.go
+++ b/pkg/app/component.go
@@ -92,6 +92,17 @@ type Navigator interface {
 	OnNav(Context)
 }
 
+// DismountEnforcer defines a contract for components that enforce
+// a dismount operation when they undergo updates. Implementing this interface
+// allows components to specify whether they should be removed and re-added
+// upon updates instead of being modified in place.
+type DismountEnforcer interface {
+	// CompoID returns an identifier used to determine a component's identity.
+	// When a component update occurs, a mismatch in IDs triggers the dismount
+	// of the current component and the mounting of a new version.
+	CompoID() string
+}
+
 // Updater encapsulates components that require specific behaviors or reactions
 // when one of their exported fields is updated by the closest parent component.
 // Implementing the Updater interface allows components to define responsive

--- a/pkg/app/component_test.go
+++ b/pkg/app/component_test.go
@@ -148,3 +148,14 @@ func (c *navigatorComponent) OnNav(ctx Context) {
 		c.onNav(ctx)
 	}
 }
+
+type dismountEnforcerComponent struct {
+	Compo
+
+	Text string
+	id   string
+}
+
+func (c *dismountEnforcerComponent) CompoID() string {
+	return c.id
+}

--- a/pkg/app/node.go
+++ b/pkg/app/node.go
@@ -107,7 +107,7 @@ func (m nodeManager) Mount(ctx Context, depth uint, v UI) (UI, error) {
 
 	switch v := v.(type) {
 	case *text:
-		return m.mountText(depth, v)
+		return m.mountText(v)
 
 	case HTML:
 		return m.mountHTML(ctx, depth, v)
@@ -125,7 +125,7 @@ func (m nodeManager) Mount(ctx Context, depth uint, v UI) (UI, error) {
 	}
 }
 
-func (m nodeManager) mountText(depth uint, v *text) (UI, error) {
+func (m nodeManager) mountText(v *text) (UI, error) {
 	if v.Mounted() {
 		return nil, errors.New("text is already mounted").
 			WithTag("parent-type", reflect.TypeOf(v.parent())).
@@ -339,6 +339,9 @@ func (m nodeManager) CanUpdate(v, new UI) bool {
 	}
 
 	switch v.(type) {
+	case DismountEnforcer:
+		return v.(DismountEnforcer).CompoID() == new.(DismountEnforcer).CompoID()
+
 	case *htmlElem, *htmlElemSelfClosing:
 		return v.(HTML).Tag() == new.(HTML).Tag()
 

--- a/pkg/app/node_test.go
+++ b/pkg/app/node_test.go
@@ -821,6 +821,54 @@ func TestNodeManagerUpdate(t *testing.T) {
 		require.Nil(t, newCompo)
 	})
 
+	t.Run("update dismount enforcer component with same compo ids does not trigger dismount", func(t *testing.T) {
+		var m nodeManager
+
+		old := &dismountEnforcerComponent{
+			Text: "hi",
+			id:   "foo",
+		}
+		elem, err := m.Mount(ctx, 1, Div().Body(old))
+		require.NoError(t, err)
+		require.NotNil(t, elem)
+
+		update := &dismountEnforcerComponent{
+			Text: "bye",
+			id:   "foo",
+		}
+		updatedElem, err := m.Update(ctx, elem, Div().Body(update))
+		require.NoError(t, err)
+
+		new := updatedElem.(*htmlDiv).body()[0]
+		require.True(t, old == new)
+		require.False(t, update == new)
+		require.Equal(t, "bye", new.(*dismountEnforcerComponent).Text)
+	})
+
+	t.Run("update dismount enforcer component with differen compo ids triggers dismount", func(t *testing.T) {
+		var m nodeManager
+
+		old := &dismountEnforcerComponent{
+			Text: "hi",
+			id:   "foo",
+		}
+		elem, err := m.Mount(ctx, 1, Div().Body(old))
+		require.NoError(t, err)
+		require.NotNil(t, elem)
+
+		update := &dismountEnforcerComponent{
+			Text: "bye",
+			id:   "bar",
+		}
+		updatedElem, err := m.Update(ctx, elem, Div().Body(update))
+		require.NoError(t, err)
+
+		new := updatedElem.(*htmlDiv).body()[0]
+		require.False(t, old == new)
+		require.True(t, update == new)
+		require.Equal(t, "bye", new.(*dismountEnforcerComponent).Text)
+	})
+
 	t.Run("update raw html replaces its value", func(t *testing.T) {
 		var m nodeManager
 
@@ -1209,7 +1257,6 @@ func TestCanUpdateValue(t *testing.T) {
 }
 
 func TestComponent(t *testing.T) {
-
 	t.Run("parent component is returned", func(t *testing.T) {
 		compo := &compoWithCustomRoot{Root: Div()}
 


### PR DESCRIPTION
## Changes
Introduces the `DismountEnforcer` interface, which allows a component to be forcibly dismounted and remounted when an update occurs.

You can force a component to update by implementing the following interface:

```go
// DismountEnforcer defines a contract for components that enforce
// a dismount operation when they undergo updates. Implementing this interface
// allows components to specify whether they should be removed and re-added
// upon updates instead of being modified in place.
type DismountEnforcer interface {
	// CompoID returns an identifier used to determine a component's identity.
	// When a component update occurs, a mismatch in IDs triggers the dismount
	// of the current component and the mounting of a new version.
	CompoID() string
}
```

## Issues
- https://github.com/maxence-charriere/go-app/issues/1043

@oderwat @C4a15Wh Can you try this?