### PR TITLE
Resolve the build error encountered when using TinyGo.

### DIFF
--- a/pkg/app/node.go
+++ b/pkg/app/node.go
@@ -771,30 +771,29 @@ func (m nodeManager) encodeRawHTML(w *bytes.Buffer, depth int, v *raw) {
 
 func canUpdateValue(v, new reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.String,
-		reflect.Bool,
-		reflect.Int,
-		reflect.Int64,
-		reflect.Int32,
-		reflect.Int16,
-		reflect.Int8,
-		reflect.Uint,
-		reflect.Uint64,
-		reflect.Uint32,
-		reflect.Uint16,
-		reflect.Uint8,
-		reflect.Float64,
-		reflect.Float32:
-		return !v.Equal(new)
-
+	case reflect.String:
+		return v.String() != new.String()
+	case reflect.Bool:
+		return v.Bool() != new.Bool()
+	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
+		return v.Int() != new.Int()
+	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+		return v.Uint() != new.Uint()
+	case reflect.Float64, reflect.Float32:
+		return v.Float() != new.Float()
 	default:
-		switch v.Interface().(type) {
-		case time.Time:
-			return !v.Equal(new)
+		vInterface := v.Interface()
+		newInterface := new.Interface()
 
-		default:
-			return !reflect.DeepEqual(v.Interface(), new.Interface())
+		// Special handling for time.Time
+		if _, ok := vInterface.(time.Time); ok {
+			t1, _ := vInterface.(time.Time)
+			t2, _ := newInterface.(time.Time)
+			return !t1.Equal(t2)
 		}
+
+		// For other types, fall back to reflect.DeepEqual
+		return !reflect.DeepEqual(vInterface, newInterface)
 	}
 }
 


### PR DESCRIPTION
When attempting to build the application using TinyGo, an error occurs:

```
tinygo build -target wasm -o web/app.wasm -no-debug -panic=trap
# github.com/maxence-charriere/go-app/v10/pkg/app
../../../go/pkg/mod/github.com/maxence-charriere/go-app/v10@v10.1.1/pkg/app/node.go:788:13: v.Equal undefined (type reflect.Value has no field or method Equal)
../../../go/pkg/mod/github.com/maxence-charriere/go-app/v10@v10.1.1/pkg/app/node.go:793:14: v.Equal undefined (type reflect.Value has no field or method Equal)
```
The problem was that TinyGo's implementation of the `reflect` package is more limited than standard Go's. The `Equal` method that exists on `reflect.Value` in standard Go is not available in TinyGo.

1. Handle each primitive type explicitly using the appropriate getter methods (`String()`, `Bool()`, `Int()`, etc.)
2. For the time.Time case, extract the actual values and use the `Equal` method on the time.Time type itself
3. Keep the reflect.DeepEqual fallback for other types
