### PR TITLE
Deprecated meta tag "apple-mobile-web-app-capable"

### DIFF
--- a/pkg/app/http.go
+++ b/pkg/app/http.go
@@ -658,7 +658,7 @@ func (h *Handler) servePage(w http.ResponseWriter, r *http.Request) {
 					Name("viewport").
 					Content("width=device-width, initial-scale=1, viewport-fit=cover"),
 				Meta().
-					Name("apple-mobile-web-app-capable").
+					Name("mobile-web-app-capable").
 					Content("yes"),
 				Meta().
 					Property("og:url").


### PR DESCRIPTION
Chrome: 
```<meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes">```

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/c5915ffd-901a-40fa-89fc-741aecfbd98a" />
