### PR TITLE
Fix setting attributes, especially on inputs

### DIFF
--- a/pkg/app/attribute.go
+++ b/pkg/app/attribute.go
@@ -26,7 +26,7 @@ func (a attributes) Set(name string, value any) {
 		v = toAttributeValue(value)
 	}
 
-	switch v {
+	switch name {
 	case "cite",
 		"data",
 		"download",


### PR DESCRIPTION
This fixes a bug where the new _value_ was checked in the attribute switch statement, instead of the attribute name.

This caused inputs, in particular, to not properly accept changes when the value was set to the empty string.