### PR TITLE
Support bool in ValueTo

### DIFF
--- a/pkg/app/strings.go
+++ b/pkg/app/strings.go
@@ -86,6 +86,10 @@ func stringTo(s string, v any) error {
 		f, _ := strconv.ParseFloat(s, 32)
 		val.SetFloat(f)
 
+	case reflect.Bool:
+		b, _ := strconv.ParseBool(s)
+		val.SetBool(b)
+
 	default:
 		return errors.New("string cannot be converted to receiver type").
 			WithTag("string", s).

--- a/pkg/app/strings_test.go
+++ b/pkg/app/strings_test.go
@@ -12,6 +12,33 @@ func TestStringToString(t *testing.T) {
 	require.Equal(t, "hello", s)
 }
 
+func TestStringToBool(t *testing.T) {
+	var b bool
+	err := stringTo("true", &b)
+	require.NoError(t, err)
+	require.Equal(t, true, b)
+
+	err = stringTo("false", &b)
+	require.NoError(t, err)
+	require.Equal(t, false, b)
+
+	err = stringTo("1", &b)
+	require.NoError(t, err)
+	require.Equal(t, true, b)
+
+	err = stringTo("0", &b)
+	require.NoError(t, err)
+	require.Equal(t, false, b)
+
+	err = stringTo("", &b)
+	require.NoError(t, err)
+	require.Equal(t, false, b)
+
+	err = stringTo("bogus", &b)
+	require.NoError(t, err)
+	require.Equal(t, false, b)
+}
+
 func TestStringToInt(t *testing.T) {
 	var i int
 	var i8 int8


### PR DESCRIPTION
This adds support for boolean receivers in `ValueTo`.

I had originally added it to support an `input` with a type of `checkbox` using the same code structure as everything else, but it turned out that I needed a custom `ValueTo`, since `input` uses `e.target.checked`, not `e.target.value`.

Anyway, this prevents an error when using `ValueTo` with a `bool` receiver.