### PR TITLE
fix: initialize http.Handler in prefixedResourceResolver to avoid nil pointer dereference

### DIFF
--- a/pkg/app/resource.go
+++ b/pkg/app/resource.go
@@ -74,6 +74,10 @@ func (r remoteResourceResolver) Resolve(location string) string {
 // will be resolved as "/assets/web/main.css".
 func PrefixedLocation(prefix string) ResourceResolver {
 	return prefixedResourceResolver{
+		localResourceResolver: localResourceResolver{
+			Handler:   http.FileServer(http.Dir("")),
+			directory: "",
+		},
 		prefix: prefix,
 	}
 }


### PR DESCRIPTION
The resource resolver returned by `app.PrefixedLocation(prefix string)` panics for `/web/*` assets as the embedded `http.Handler` is never initailized, and there is no way to initialize it from outside the package. This fix solves the issue by initializing the embedded `localResourceResolver` to the current directory (just like `app.LocalDir("")` does).