### PR TITLE
Allow generating static files from an http.Handler

### DIFF
--- a/pkg/app/static.go
+++ b/pkg/app/static.go
@@ -24,6 +24,12 @@ func GenerateStaticWebsite(dir string, h *Handler, pages ...string) error {
 	return GenerateStaticWebsiteFromMux(dir, h, pages...)
 }
 
+// GenerateStaticWebsiteFromMux generates the files to run a PWA built with go-app as a
+// static website in the specified directory. Static websites can be used with
+// hosts such as Github Pages.
+//
+// Note that app.wasm must still be built separately and put into the web
+// directory.
 func GenerateStaticWebsiteFromMux(dir string, h http.Handler, pages ...string) error {
 	if dir == "" {
 		dir = "."

--- a/pkg/app/static.go
+++ b/pkg/app/static.go
@@ -21,6 +21,10 @@ import (
 // Note that app.wasm must still be built separately and put into the web
 // directory.
 func GenerateStaticWebsite(dir string, h *Handler, pages ...string) error {
+	return GenerateStaticWebsiteFromMux(dir, h, pages...)
+}
+
+func GenerateStaticWebsiteFromMux(dir string, h http.Handler, pages ...string) error {
 	if dir == "" {
 		dir = "."
 	}

--- a/pkg/app/wasm.go
+++ b/pkg/app/wasm.go
@@ -4,12 +4,18 @@
 package app
 
 import (
+	"net/http"
 	"runtime"
 
 	"github.com/maxence-charriere/go-app/v11/pkg/errors"
 )
 
 func GenerateStaticWebsite(dir string, h *Handler, pages ...string) error {
+	panic(errors.New("unsupported instruction").
+		WithTag("architecture", runtime.GOARCH))
+}
+
+func GenerateStaticWebsiteFromMux(dir string, h http.Handler, pages ...string) error {
 	panic(errors.New("unsupported instruction").
 		WithTag("architecture", runtime.GOARCH))
 }


### PR DESCRIPTION
app.Handler is an http.Handler, but the static site generation requires an *app.Handler struct.  I'd like to simply switch this to use an http.Handler directly, but for now, I've added a second function that accepts one, and the current one is implemented using that second function.